### PR TITLE
Replaced `jq` with a single-purpose Python script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ src-vector-tiles:
 	mkdir src-vector-tiles
 	# Try with --wildcards for GNU tar, but fall back to BSD tar syntax for Mac.
 	curl -sL $(VECTOR_TILES) \
-	| jq '.tarball_url' --raw-output \
+	| ./extract-tarball-url.py \
 	| xargs curl -sL | ( \
 	    tar -zxv -C src-vector-tiles --strip-components=2 --exclude=README.md --wildcards '*/docs/' \
 	 || tar -zxv -C src-vector-tiles --strip-components=2 --exclude=README.md '*/docs/' \
@@ -54,7 +54,7 @@ src-terrain-tiles:
 	mkdir src-terrain-tiles
 	# Try with --wildcards for GNU tar, but fall back to BSD tar syntax for Mac.
 	curl -sL $(TERRAIN_TILES) \
-	| jq '.tarball_url' --raw-output \
+	| ./extract-tarball-url.py \
 	| xargs curl -sL | ( \
 	    tar -zxv -C src-terrain-tiles --strip-components=2 --exclude=README.md --wildcards '*/docs/' \
 	 || tar -zxv -C src-terrain-tiles --strip-components=2 --exclude=README.md '*/docs/' \

--- a/README.md
+++ b/README.md
@@ -12,7 +12,6 @@ checkout of this repository:
 
 ```shell
 # Prepare virtualenv and install local dependencies
-brew install jq
 virtualenv -p python3 venv
 source venv/bin/activate
 pip install -Ur requirements.txt

--- a/circle.yml
+++ b/circle.yml
@@ -5,7 +5,7 @@ machine:
 dependencies:
   override:
     - sudo apt-get update -y
-    - sudo apt-get install -y curl jq
+    - sudo apt-get install -y curl
 
 test:
   override:

--- a/extract-tarball-url.py
+++ b/extract-tarball-url.py
@@ -1,0 +1,8 @@
+#!/usr/bin/env python
+import json, sys, pipes
+
+input = json.load(sys.stdin)
+value = input.get('tarball_url', '')
+output = pipes.quote(value)
+
+print(output)


### PR DESCRIPTION
This simplifies the usage instructions by one line.