### PR TITLE
Add pip install requirements.txt

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -6,6 +6,7 @@ dependencies:
   override:
     - sudo apt-get update -y
     - sudo apt-get install -y curl jq
+    - pip install -r requirements.txt
 
 test:
   override:


### PR DESCRIPTION
This should always have existed; not sure how we got by so long without it around. Possibly from a manual cache at some point in the distant past, and now surfaced due to CircleCI cache-busted repository rename from `mapzen-docs-generator` to `documentation`? 