### PR TITLE
Update base URL for Cartography docs

### DIFF
--- a/config/cartography.yml
+++ b/config/cartography.yml
@@ -13,4 +13,4 @@ pages:
 extra:
   site_subtitle: 'Get everything you need to use Mapzen basemaps and icons in your applications.'
   project_repo_url: https://github.com/tangrams/cartography-docs
-  docs_base_url: https://github.com/tangrams/cartography-docs/master
+  docs_base_url: https://github.com/tangrams/cartography-docs/tree/master


### PR DESCRIPTION
The "Edit this page on GitHub" link is on the formatted docs is broken for the Cartography docs section. 

Working on precog now: https://precog.mapzen.com/mapzen/mapzen-docs-generator/rhonda-carto-repo/documentation/cartography/