### PR TITLE
Update readme and setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-# Mapzen's documentation pipeline
+# Mapzen documentation
 
-We write our documentation in Markdown and store them in GitHub, and use a [MkDocs](http://www.mkdocs.org/)-based automated workflow to convert them into friendlier static-site documentation pages hosted at https://mapzen.com/documentation/. You can read more about this on our [blog post](https://mapzen.com/blog/doc-site/).
+Mapzen writes documentation in Markdown, stores the source files in GitHub, and uses a [MkDocs](http://www.mkdocs.org/)-based automated workflow to convert them into static-site documentation pages hosted at https://mapzen.com/documentation/. You can read more about this process in the [blog post](https://mapzen.com/blog/doc-site/).
 
-## Installation, Testing, And Use
+## Build locally
 
-### Build locally
+Clone the repository locally and open a terminal window to the mapzen-docs-generator folder.
 
 On a Mac, assuming you have [Homebrew](http://brew.sh) and 
 [Python 3](https://docs.python.org/3/using/mac.html) installed, and a local

--- a/README.md
+++ b/README.md
@@ -1,10 +1,34 @@
 # Mapzen documentation
 
-Mapzen writes documentation in Markdown, stores the source files in GitHub, and uses a [MkDocs](http://www.mkdocs.org/)-based automated workflow to convert them into static-site documentation pages hosted at https://mapzen.com/documentation/. You can read more about this process in the [blog post](https://mapzen.com/blog/doc-site/).
+This repository contains the configuration files and tools used to build Mapzen's documentation site [mapzen.com/documentation](https://mapzen.com/documentation/). 
+
+The documentation is built with an open-source Python tool called [MkDocs](http://www.mkdocs.org/), which formats GitHub markdown files in to a static, HTML website. Note that while MkDocs reads just one source, Mapzen has enhanced it to integrate multiple repositories. There have been additional enhancements to support URL redirects and renaming files in the output help. You can read more about this process in the [blog post](https://mapzen.com/blog/doc-site/).
+
+As long as a markdown file is listed in the build configuration, changes in the source files in the GitHub branch that is being pulled into the help (typically, the master branch) appear automatically on https://mapzen.com/documentation. This is through continuous integration processes that run in the source respositories and in this one.
+
+## Source file locations
+
+The source files to build Mapzen's documentation may be found in separate documentation repositories in a GitHub organization, as a documentation folder in a project's repository, or within this repository. Getting changes onto the documentation site may require the files be on a certain branch or in a special release.
+
+|                           Product                        | Source location | Updates  |
+|----------------------------------------------------------|---------------------|----------|
+| [Overview](http://www.mapzen.com/documentation/overview) | https://github.com/mapzen/mapzen-docs-generator/tree/master/docs  | Push to Master  |
+| [Mapzen.js](https://mapzen.com/documentation/mapzen-js/)  | https://github.com/mapzen/mapzen.js/tree/master/docs  | Needs to be in a release  |
+| [Tangram](https://mapzen.com/documentation/tangram/) | https://github.com/tangrams/tangram-docs | Push to gh-pages   |
+| [Vector Tiles](https://mapzen.com/documentation/vector-tiles/)  | https://github.com/tilezen/vector-datasource/tree/master/docs  | Has versioning |
+| [Search](https://mapzen.com/documentation/search/)  | https://github.com/pelias/pelias-doc  | Push to Master  |
+| [Mobility](https://mapzen.com/documentation/mobility/)  | https://github.com/valhalla/valhalla-docs  | Push to Master |
+| [Metro Extracts](https://mapzen.com/documentation/metro-extracts/)  | https://github.com/mapzen/metro-extracts/tree/master/docs  | Push to Master |
+| [Terrain Tiles](https://mapzen.com/documentation/terrain-tiles/)  | https://github.com/tilezen/joerd  | Needs to be in a release  |
+| [Elevation Service](https://mapzen.com/documentation/elevation/) | https://github.com/valhalla/valhalla-docs  | Push to Master |
+| [Android SDK](https://mapzen.com/documentation/android/) | https://github.com/mapzen/android/tree/master/docs | Push to Master |
+| [iOS SDK](https://mapzen.com/documentation/ios/) | https://github.com/mapzen/ios/blob/master/docs | Push to Master |
+| [Address parsing/libpostal](https://mapzen.com/documentation/libpostal/) | https://github.com/whosonfirst/go-whosonfirst-libpostal/blob/master/docs | Push to Master |
+| [Cartography](https://mapzen.com/documentation/cartography/) | https://github.com/tangrams/cartography-docs/ | Push to Master |
 
 ## Build locally
 
-Clone the repository locally and open a terminal window to the mapzen-docs-generator folder.
+If you need to build the documentation locally for testing, clone this repository and open a terminal window to the `documentation` folder.
 
 On a Mac, assuming you have [Homebrew](http://brew.sh) and 
 [Python 3](https://docs.python.org/3/using/mac.html) installed, and a local
@@ -30,23 +54,3 @@ open http://localhost:8000/dist/
 Run `make clean` to build a clean copy of the documentation. This command deletes the previous build and makes new files.
 
 You may be able to build one section of the documentation using `make clean dist-projectname`, such as `make clean dist-tangram`.
-
-## Source files
-
-The source files to build Mapzen's documentation may be found in separate repositories in a GitHub organization, as a documentation folder in a project's repository, or within this repository. Getting changes onto the documentation site may require the files be on a certain branch or in a special release.
-
-|                           Product                        | Source location | Updates  |
-|----------------------------------------------------------|---------------------|----------|
-| [Overview](http://www.mapzen.com/documentation/overview) | https://github.com/mapzen/mapzen-docs-generator/tree/master/docs  | Push to Master  |
-| [Mapzen.js](https://mapzen.com/documentation/mapzen-js/)  | https://github.com/mapzen/mapzen.js/tree/master/docs  | Needs to be in a release  |
-| [Tangram](https://mapzen.com/documentation/tangram/) | https://github.com/tangrams/tangram-docs | Push to gh-pages   |
-| [Vector Tiles](https://mapzen.com/documentation/vector-tiles/)  | https://github.com/tilezen/vector-datasource/tree/master/docs  | Has versioning |
-| [Search](https://mapzen.com/documentation/search/)  | https://github.com/pelias/pelias-doc  | Push to Master  |
-| [Mobility](https://mapzen.com/documentation/mobility/)  | https://github.com/valhalla/valhalla-docs  | Push to Master |
-| [Metro Extracts](https://mapzen.com/documentation/metro-extracts/)  | https://github.com/mapzen/metro-extracts/tree/master/docs  | Push to Master |
-| [Terrain Tiles](https://mapzen.com/documentation/terrain-tiles/)  | https://github.com/tilezen/joerd  | Needs to be in a release  |
-| [Elevation Service](https://mapzen.com/documentation/elevation/) | https://github.com/valhalla/valhalla-docs  | Push to Master |
-| [Android SDK](https://mapzen.com/documentation/android/) | https://github.com/mapzen/android/tree/master/docs | Push to Master |
-| [iOS SDK](https://mapzen.com/documentation/ios/) | https://github.com/mapzen/ios/blob/master/docs | Push to Master |
-| [Address parsing/libpostal](https://mapzen.com/documentation/libpostal/) | https://github.com/whosonfirst/go-whosonfirst-libpostal/blob/master/docs | Push to Master |
-| [Cartography](https://mapzen.com/documentation/cartography/) | https://github.com/tangrams/cartography-docs/ | Push to Master |

--- a/README.md
+++ b/README.md
@@ -8,23 +8,23 @@ As long as a markdown file is listed in the build configuration, changes in the 
 
 ## Source file locations
 
-The source files to build Mapzen's documentation may be found in separate documentation repositories in a GitHub organization, as a documentation folder in a project's repository, or within this repository. Getting changes onto the documentation site may require the files be on a certain branch or in a special release.
+The source files to build Mapzen's documentation may be found in separate documentation repositories in a GitHub organization, as a documentation folder in a project's repository, or within this repository. Getting changes onto the documentation site may require the files be on a certain branch or in a release.
 
-|                           Product                        | Source location | Updates  |
+|                           Documentation section                       | Source location | Branch name or release  |
 |----------------------------------------------------------|---------------------|----------|
-| [Overview](http://www.mapzen.com/documentation/overview) | https://github.com/mapzen/mapzen-docs-generator/tree/master/docs  | Push to Master  |
-| [Mapzen.js](https://mapzen.com/documentation/mapzen-js/)  | https://github.com/mapzen/mapzen.js/tree/master/docs  | Needs to be in a release  |
-| [Tangram](https://mapzen.com/documentation/tangram/) | https://github.com/tangrams/tangram-docs | Push to gh-pages   |
-| [Vector Tiles](https://mapzen.com/documentation/vector-tiles/)  | https://github.com/tilezen/vector-datasource/tree/master/docs  | Has versioning |
-| [Search](https://mapzen.com/documentation/search/)  | https://github.com/pelias/pelias-doc  | Push to Master  |
-| [Mobility](https://mapzen.com/documentation/mobility/)  | https://github.com/valhalla/valhalla-docs  | Push to Master |
-| [Metro Extracts](https://mapzen.com/documentation/metro-extracts/)  | https://github.com/mapzen/metro-extracts/tree/master/docs  | Push to Master |
-| [Terrain Tiles](https://mapzen.com/documentation/terrain-tiles/)  | https://github.com/tilezen/joerd  | Needs to be in a release  |
-| [Elevation Service](https://mapzen.com/documentation/elevation/) | https://github.com/valhalla/valhalla-docs  | Push to Master |
-| [Android SDK](https://mapzen.com/documentation/android/) | https://github.com/mapzen/android/tree/master/docs | Push to Master |
-| [iOS SDK](https://mapzen.com/documentation/ios/) | https://github.com/mapzen/ios/blob/master/docs | Push to Master |
-| [Address parsing/libpostal](https://mapzen.com/documentation/libpostal/) | https://github.com/whosonfirst/go-whosonfirst-libpostal/blob/master/docs | Push to Master |
-| [Cartography](https://mapzen.com/documentation/cartography/) | https://github.com/tangrams/cartography-docs/ | Push to Master |
+| [Overview](http://www.mapzen.com/documentation/overview) | https://github.com/mapzen/mapzen-docs-generator/tree/master/docs  | Master  |
+| [Mapzen.js](https://mapzen.com/documentation/mapzen-js/)  | https://github.com/mapzen/mapzen.js/tree/master/docs  | Latest release  |
+| [Tangram](https://mapzen.com/documentation/tangram/) | https://github.com/tangrams/tangram-docs | gh-pages   |
+| [Vector tiles](https://mapzen.com/documentation/vector-tiles/)  | https://github.com/tilezen/vector-datasource/tree/master/docs  | Latest release |
+| [Search](https://mapzen.com/documentation/search/)  | https://github.com/pelias/pelias-doc  | Master  |
+| [Mobility](https://mapzen.com/documentation/mobility/)  | https://github.com/valhalla/valhalla-docs  | Master |
+| [Metro Extracts](https://mapzen.com/documentation/metro-extracts/)  | https://github.com/mapzen/metro-extracts/tree/master/docs  | Master |
+| [Terrain tiles](https://mapzen.com/documentation/terrain-tiles/)  | https://github.com/tilezen/joerd  | Latest release  |
+| [Elevation](https://mapzen.com/documentation/elevation/) | https://github.com/valhalla/valhalla-docs  | Master |
+| [Android SDK](https://mapzen.com/documentation/android/) | https://github.com/mapzen/android/tree/master/docs | Master |
+| [iOS SDK](https://mapzen.com/documentation/ios/) | https://github.com/mapzen/ios/blob/master/docs  Master |
+| [Address parsing/libpostal](https://mapzen.com/documentation/libpostal/) | https://github.com/whosonfirst/go-whosonfirst-libpostal/blob/master/docs | Master |
+| [Cartography](https://mapzen.com/documentation/cartography/) | https://github.com/tangrams/cartography-docs/ | Master |
 
 ## Build locally
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ The source files to build Mapzen's documentation may be found in separate docume
 | [Terrain tiles](https://mapzen.com/documentation/terrain-tiles/)  | https://github.com/tilezen/joerd  | Latest release  |
 | [Elevation](https://mapzen.com/documentation/elevation/) | https://github.com/valhalla/valhalla-docs  | Master |
 | [Android SDK](https://mapzen.com/documentation/android/) | https://github.com/mapzen/android/tree/master/docs | Master |
-| [iOS SDK](https://mapzen.com/documentation/ios/) | https://github.com/mapzen/ios/blob/master/docs  Master |
+| [iOS SDK](https://mapzen.com/documentation/ios/) | https://github.com/mapzen/ios/blob/master/docs | Master |
 | [Address parsing/libpostal](https://mapzen.com/documentation/libpostal/) | https://github.com/whosonfirst/go-whosonfirst-libpostal/blob/master/docs | Master |
 | [Cartography](https://mapzen.com/documentation/cartography/) | https://github.com/tangrams/cartography-docs/ | Master |
 

--- a/README.md
+++ b/README.md
@@ -30,3 +30,20 @@ open http://localhost:8000/dist/
 Run `make clean` to build a clean copy of the documentation. This command deletes the previous build and makes new files.
 
 You may be able to build one section of the documentation using `make clean dist-projectname`, such as `make clean dist-tangram`.
+
+## Source files
+
+The source files to build Mapzen's documentation may be found in separate repositories in a GitHub organization, as a documentation folder in a project's repository, or within this repository. Getting changes onto the documentation site may require the files be on a certain branch or in a special release.
+
+|                           Product                        | Source location | Updates  |
+|----------------------------------------------------------|---------------------|----------|
+| [Overview](http://www.mapzen.com/documentation/overview) | https://github.com/mapzen/mapzen-docs-generator/tree/master/docs  | Push to Master  |
+| [Mapzen.js](https://mapzen.com/documentation/mapzen-js/)  | https://github.com/mapzen/mapzen.js/tree/master/docs  | Needs to be in a release  |
+| [Tangram](https://mapzen.com/documentation/tangram/) | https://github.com/tangrams/tangram-docs | Push to gh-pages   |
+| [Vector Tiles](https://mapzen.com/documentation/vector-tiles/)  | https://github.com/tilezen/vector-datasource/tree/master/docs  | Has versioning |
+| [Search](https://mapzen.com/documentation/search/)  | https://github.com/pelias/pelias-doc  | Push to Master  |
+| [Mobility](https://mapzen.com/documentation/mobility/)  | https://github.com/valhalla/valhalla-docs  | Push to Master |
+| [Metro Extracts](https://mapzen.com/documentation/metro-extracts/)  | https://github.com/mapzen/metro-extracts/tree/master/docs  | Push to Master |
+| [Terrain Tiles](https://mapzen.com/documentation/terrain-tiles/)  | https://github.com/tilezen/joerd  | Needs to be in a release  |
+| [Elevation Service](https://mapzen.com/documentation/elevation/) | https://github.com/valhalla/valhalla-docs  | Push to Master |
+| [Android SDK](https://mapzen.com/documentation/android/) | https://github.com/mapzen/android/tree/master/docs | Push to Master |

--- a/README.md
+++ b/README.md
@@ -47,3 +47,6 @@ The source files to build Mapzen's documentation may be found in separate reposi
 | [Terrain Tiles](https://mapzen.com/documentation/terrain-tiles/)  | https://github.com/tilezen/joerd  | Needs to be in a release  |
 | [Elevation Service](https://mapzen.com/documentation/elevation/) | https://github.com/valhalla/valhalla-docs  | Push to Master |
 | [Android SDK](https://mapzen.com/documentation/android/) | https://github.com/mapzen/android/tree/master/docs | Push to Master |
+| [iOS SDK](https://mapzen.com/documentation/ios/) | https://github.com/mapzen/ios/blob/master/docs | Push to Master |
+| [Address parsing/libpostal](https://mapzen.com/documentation/libpostal/) | https://github.com/whosonfirst/go-whosonfirst-libpostal/blob/master/docs | Push to Master |
+| [Cartography](https://mapzen.com/documentation/cartography/) | https://github.com/tangrams/cartography-docs/ | Push to Master |

--- a/SETUP.md
+++ b/SETUP.md
@@ -1,22 +1,17 @@
-# Set up and documentation update instructions
+# Set up and build documentation
 
-## Follow the setup and writing instructions
+## Follow the writing instructions
 
 - Follow the guidelines of the [writing style guide](https://github.com/mapzen/styleguide/tree/master/src/site/guides) when it comes to writing technical documentation.
 - Include an `index.md` file at the root folder of your documentation. (Note: [MkDocs will allow this to be customized in the future.](https://github.com/mkdocs/mkdocs/issues/608))
 - Start each page with a top-level heading with one `#` symbol, except for the index.md. The home page should not have a title because it would most likely duplicate the banner on the page.
-
-## Make your markdown compatible with GitHub and the documentation site
-
-- [Markdown formatting guide](https://github.com/adam-p/markdown-here/wiki/Markdown-Cheatsheet)
+- Follow the [Markdown formatting guide](https://github.com/adam-p/markdown-here/wiki/Markdown-Cheatsheet)
 - Add blank lines between different blocks of content: before and after bulleted lists, numbered lists, code blocks, images, and so on.
 - If a code block or image is supposed to be part of a list, remember the blank lines before and after, and also indent it four spaces. Using or mixing tabs might cause problems. Python Markdown is a lot pickier about this than GitHub-flavored Markdown, causing lists to nest improperly or break numbering altogether.
 
 ## Add a new section to the documentation
 
-Adding an entirely new section of the help has many factors, ranging from design decisions on the mapzen.com website to the mechanics of building the help.
-
-In general, there are four files that you need to update to do this. You can often copy, paste, and modify existing files to understand what needs to be updated to add the new section.
+Adding an entirely new section of the help has many factors, ranging from design decisions on the mapzen.com website to the mechanics of building the help. In general, there are four files that you need to update to do this. You can often copy, paste, and modify existing files to understand what needs to be updated to add the new section.
 
 1. Add an entry to https://github.com/mapzen/documentation/tree/master/src-index to update the index file that is the landing page for the documentation.
 2. Add a new config `.yml` file to https://github.com/mapzen/documentation/tree/master/config. This builds the table of contents and sets the links to the source files so the `Edit this page on GitHub` links work properly (these allow users to go directly to the source file to propose edits).
@@ -25,7 +20,7 @@ In general, there are four files that you need to update to do this. You can oft
 
 If you are removing sections from the help, you will need to consider adding URL redirects to the `index.yml` file.
 
-## Add entry to the documentation table of contents
+## Add an entry to the documentation table of contents
 
 To display on the documentation site, you need to add a topic to a configuration file. Otherwise, the topic exists only in the repository. It is fine to have topics in the repository that are not in the help system, as long as you know that is happening.
 
@@ -43,17 +38,17 @@ You need to update the config.yml file to add a topic, remove one, or rename it 
 
 File names are case-sensitive, so 'Scene-file.md' is different from 'scene-file.md'. The file name in the config file must exactly match the source file, or else you will get a build error.
 
-### Preview changes that are in a branch
+### Preview content changes that are in a branch
 
 If you've created a pull request in the documentation repository, and your content changes are in the branch that the help is built from (usually, master), you can view changes at [precog.mapzen.com/mapzen/documentation/](precog.mapzen.com/mapzen/documentation/). 
 
-If the content changes are in a different branch, you need to make temporary changes to the build process. 
+If the content changes are in a different branch, you need to make temporary changes to the build process to locate your branch. 
 
 1. Create a branch in the `documentation` repository.
 1. Open the Makefile
 2. In another tab, open the latest commit on the branch you're working on in the particular project repository
 3. Copy the full commit ID
-4. In the Makefile, edit the URL and replace the phrase (typically 'master') before .tar.gz with the commit ID, for example:
+4. In the Makefile, edit the URL and replace the phrase (typically, 'master') before .tar.gz with the commit ID, for example:
 
 `EXTRACTS = https://github.com/mapzen/metro-extracts/archive/master.tar.gz --> EXTRACTS = https://github.com/mapzen/metro-extracts/archive/2d3ef32e1a6fc51be6908968e32902a04a016dee.tar.gz`
 
@@ -139,9 +134,13 @@ If you move content or rename a repository, you need to update the source locati
 The Makefile collects and builds the documentation. Here are the general steps it takes. 
 
 - It first retrieves the source documentation file, which is available from GitHub inside a pre-packaged archive with the extension `tar.gz`. 
+    
     `TANGRAM = https://github.com/tangrams/tangram-docs/archive/gh-pages.tar.gz`
+    
 - It uncompresses the file, with a line further down in the Makefile that looks something like this. This will extract the files into the `src/project-name` directory, which makes them available to mkdocs. 
+
     `curl -sL $(TANGRAM) | tar -zxv -C src-tangram --strip-components=2 tangram-docs-gh-pages/pages`
     
 You can use this line to change the branch used as the source of the documentation with these lines, which can be handy for testing purposes. This is accomplished by replacing `gh-pages` with the name of another branch. Note that you'll need to convert any slashes in the branch name to dashes. For example, if your repo name is `tangram-docs` and your branch name is `cleanup`, the reference in the `curl` command will look like `tangram-docs-cleanup`, and the full command will be:
-    `curl -sL $(TANGRAM) | tar -zxv -C src-tangram --strip-components=2 tangram-docs-cleanup/pages`
+
+`curl -sL $(TANGRAM) | tar -zxv -C src-tangram --strip-components=2 tangram-docs-cleanup/pages`

--- a/SETUP.md
+++ b/SETUP.md
@@ -1,64 +1,147 @@
 # Set up and documentation update instructions
 
-## Follow MkDocs requirements
+## Follow the setup and writing instructions
 
+- Follow the guidelines of the [writing style guide](https://github.com/mapzen/styleguide/tree/master/src/site/guides) when it comes to writing technical documentation.
 - Include an `index.md` file at the root folder of your documentation. (Note: [MkDocs will allow this to be customized in the future.](https://github.com/mkdocs/mkdocs/issues/608))
-- Include all local documentation assets, such as images, inside this root folder (or link to an external source).
 - Start each page with a top-level heading with one `#` symbol, except for the index.md. The home page should not have a title because it would most likely duplicate the banner on the page.
-
-### Preview the changes on the precog website
-
-If you've created a Pull Request in the mapzen-docs-generator repository, you can view changes in Precog at [precog.mapzen.com/mapzen/mapzen-docs-generator/](precog.mapzen.com/mapzen/mapzen-docs-generator/). This will only show changes that have been done in this specific repository. If the changes you're doing on a particular repository aren't live yet, you need to edit the **Makefile** to reflect the branch that you're working on. You can do this by:
-
-1. Opening the Makefile
-2. In another tab, open the latest commit on the branch you're working on in the particular project repository
-3. Copy the full commit ID
-4. In the mapzen-docs-generator Makefile, edit the URL and replace the phrase (typically 'master') before .tar.gz with the commit ID, for example:
-
-`EXTRACTS = https://github.com/mapzen/metro-extracts/archive/master.tar.gz --> EXTRACTS = https://github.com/mapzen/metro-extracts/archive/2d3ef32e1a6fc51be6908968e32902a04a016dee.tar.gz`
-
-At the moment, this will be needed to be updated with the new commit ID when needed.
 
 ## Make your markdown compatible with GitHub and the documentation site
 
 - [Markdown formatting guide](https://github.com/adam-p/markdown-here/wiki/Markdown-Cheatsheet)
 - Add blank lines between different blocks of content: before and after bulleted lists, numbered lists, code blocks, images, and so on.
-- If a code block or image is supposed to be part of a list, remember the blank lines before and after, and _also_ indent it **four spaces**. Using or mixing tabs might cause problems. Python Markdown is a lot pickier about this than GitHub-flavored Markdown, causing lists to nest improperly or break numbering altogether.
+- If a code block or image is supposed to be part of a list, remember the blank lines before and after, and also indent it four spaces. Using or mixing tabs might cause problems. Python Markdown is a lot pickier about this than GitHub-flavored Markdown, causing lists to nest improperly or break numbering altogether.
 
-## Update the documentation source file
+## Add a new section to the documentation
 
-There are two (sometimes three) things to do if you want to change the GitHub source of documentation.
+Adding an entirely new section of the help has many factors, ranging from design decisions on the mapzen.com website to the mechanics of building the help.
 
-1. **Update the project configuration file.** This is located at `config/project-name.yml` file. Look for the `extra` key and find or create, one level in, the `docs_base_url` key. This is used to build the "edit in GitHub" links at the bottom of each page. The actual path and file name are appended to the base URL. It will look something like this:
+In general, there are four files that you need to update to do this. You can often copy, paste, and modify existing files to understand what needs to be updated to add the new section.
+
+1. Add an entry to https://github.com/mapzen/documentation/tree/master/src-index to update the index file that is the landing page for the documentation.
+2. Add a new config `.yml` file to https://github.com/mapzen/documentation/tree/master/config. This builds the table of contents and sets the links to the source files so the `Edit this page on GitHub` links work properly (these allow users to go directly to the source file to propose edits).
+3. Update the Makefile in https://github.com/mapzen/documentation/blob/master/Makefile that pulls together all resources for the help.
+4. Update the automated test at https://github.com/mapzen/documentation/blob/master/run-checklist.py.
+
+If you are removing sections from the help, you will need to consider adding URL redirects to the `index.yml` file.
+
+## Add entry to the documentation table of contents
+
+To display on the documentation site, you need to add a topic to a configuration file. Otherwise, the topic exists only in the repository. It is fine to have topics in the repository that are not in the help system, as long as you know that is happening.
+
+You need to update the config.yml file to add a topic, remove one, or rename it in the table of contents.
+
+1. Go to https://github.com/mapzen/documentation/tree/master/config
+2. Find the .yml file for your section of help. For example, Mapzen Mobility can be found in mobility.yml.
+3. Under `pages:`, make the change to the table of contents. The topic in the `Home:` position should always be only `index.md` (under MkDocs rules). Add topics by including a heading, contained in single quotation mark, followed by a colon and the name of the md file. For example, `'API reference': 'api-reference.md'`
+4. You can add nesting in the table of contents by indenting the lines underneath the heading.
+
+```json
+- Concept overviews:
+  - 'The Scene file': 'Scene-file.md'
+```
+
+File names are case-sensitive, so 'Scene-file.md' is different from 'scene-file.md'. The file name in the config file must exactly match the source file, or else you will get a build error.
+
+### Preview changes that are in a branch
+
+If you've created a pull request in the documentation repository, and your content changes are in the branch that the help is built from (usually, master), you can view changes at [precog.mapzen.com/mapzen/documentation/](precog.mapzen.com/mapzen/documentation/). 
+
+If the content changes are in a different branch, you need to make temporary changes to the build process. 
+
+1. Create a branch in the `documentation` repository.
+1. Open the Makefile
+2. In another tab, open the latest commit on the branch you're working on in the particular project repository
+3. Copy the full commit ID
+4. In the Makefile, edit the URL and replace the phrase (typically 'master') before .tar.gz with the commit ID, for example:
+
+`EXTRACTS = https://github.com/mapzen/metro-extracts/archive/master.tar.gz --> EXTRACTS = https://github.com/mapzen/metro-extracts/archive/2d3ef32e1a6fc51be6908968e32902a04a016dee.tar.gz`
+
+Note: If you are modifying the `VALHALLA` section, you will need to add a variable for it because the elevation documentation will break. 
+
+## Add URL redirects when you rename or move files
+
+Mapzen wrote some additional Python code to enable URLs to forward when files are renamed or moved. For example, the existing Turn-by-Turn, Optimized Route, and Matrix sections of the help were grouped under a Mobility section when they were packaged into a product called Mapzen Mobility. Because adding mobility changed the URLs, redirects allowed the previous topics to be found in the new help.
+
+For example, https://mapzen.com/documentation/turn-by-turn/api-reference/ redirects to https://mapzen.com/documentation/mobility/turn-by-turn/api-reference/ (note the mobility in the URL).
+
+You will also need to do this when a file is removed or renamed in GitHub, and it has existed long enough that users may have bookmarked it or it can be found through search engines.
+
+1. Go to https://github.com/mapzen/mapzen-docs-generator/tree/master/config
+2. Find the .yml file for your section of help. For example, Mapzen Mobility can be found in mobility.yml.
+3. Look for a section named `mz:redirects:`. If one is not present, add it after the `pages:` section.
+4. Add a new line underneath, indent, and add the portion of the current URL to redirect, followed by a colon and the new URL.
+
+Here is a sample from the mobility.yml.
+
+```
+mz:redirects:
+  'turn-by-turn': 'turn-by-turn/api-reference'
+  'matrix': 'matrix/api-reference'
+  'optimized': 'optimized/api-reference'
+```
+
+Behind the scenes, this calls setup-redirects.py during the build process.
+
+The base URL for all help is https://mapzen.com/documentation.
+This means that the base URL + left part of the colon is https://mapzen.com/documentation/turn-by-turn.
+
+When the script runs, the URL will redirect to the base URL + this section name from the config file (/mobility/) + the right side of the colon. This forms https://mapzen.com/documentation/mobility/turn-by-turn/api-reference.
+
+Similarly, for the `matrix` entry, https://mapzen.com/documentation/matrix will redirect to https://mapzen.com/documentation/mobility/matrix/api-reference.
+
+Note: you must use the redirects functionality anytime you are adding topics that fall under the mobility/turn-by-turn section of help because it takes on a different URL structure than the GitHub repository.
+
+Note: if you completely remove a section from the help, you should put your `mz:redirects` in the `index.yml` file. For example, the `turn-by-turn.yml` file was deleted during a product reorganization process, so redirects from that section of help are in `index.yml`.
+
+## Use a URL structure different from the source file organization
+
+MkDocs uses the exact file name and folder structure from the folder repository to build the URL for the help. This means that a file called `map_basics.md` becomes `/map_basics` with an underscore in the output documentation, when the URLs should ideally only have hyphens.
+
+If you group markdown files in a folder in GitHub, the files will also have this structure in the URL. For example, if you have a folder called `api-reference-docs` with a file in it called `map-basics.md`, the output URL will include `api-reference-docs/map-basics`. In some cases, this adds unnecessary complexity and inconsistency in the URLs.
+
+The simplest way around this is to rename or move the files in GitHub. When changing the source does not make sense, use the functions in the help build process.
+
+1. Go to https://github.com/mapzen/mapzen-docs-generator/tree/master/config
+2. Find the .yml file for your section of help. For example, Mapzen Mobility can be found in mobility.yml.
+3. Look for a section named `mz:renames:`. If one is not present, add it before the `pages:` section.
+4. Add a new line underneath, indent, and add the portion of the current URL to redirect, followed by a colon and the new path or filename.
+5. In the `pages:` section, use the new name of the file.
+
+Here is a sample from the mobility.yml.
+
+```
+mz:renames:
+  'optimized_route/api-reference.md': 'optimized/api-reference.md'
+  'api-reference.md': 'turn-by-turn/api-reference.md'
+```
+
+When the script runs, it will look in the GitHub source files for a folder named `optimized_route` (note the underscore) and a file in it called `api-reference.md`. It will then output to a temporary location during the build process a folder called `optimized` with the file in it still named `api-reference.md`. If you needed to rename the file, you could do that, too.
+
+In the second entry, it will look at the root level of the GitHub source for a file called `api-reference.md` and output it to a folder named `turn-by-turn`.
+
+## Change the documentation source location permanently
+
+If you move content or rename a repository, you need to update the source location to make the documentation build succeed and see your changes.
+
+1. Update the project configuration file. This is located at `config/project-name.yml` file. Look for the `extra` key and find or create, one level in, the `docs_base_url` key. This is used to build the `Edit this page on GitHub` links at the bottom of each page. It will look something like this:
 
     ```yml
     extra:
       docs_base_url: https://github.com/mapzen/mapzen-docs/tree/master/metro-extracts
     ```
 
-2. **Update the repository path in the Makefile.** The Makefile is located in this repo's root, and is called `Makefile`. This step is a little harder and benefits from some knowledge of shell scripting and `Make`. Generally, you want to first retrieve the source documentation file, which is available from GitHub inside a pre-packaged archive with the extension `tar.gz`. You locate it by setting a variable with the file's location, which might look something like this:
+2. Update the repository path in the Makefile.
+3. Create redirects, if necessary. Sometimes you have to change names for the files or move files into other folders, or you delete a file. You should make a redirect link so users can find the new topic. If you need to create a different path in the documentation output than the file name or folder system, consider whether you should make these changes in the GitHub repository first.
 
+## Makefile reference
+
+The Makefile collects and builds the documentation. Here are the general steps it takes. 
+
+- It first retrieves the source documentation file, which is available from GitHub inside a pre-packaged archive with the extension `tar.gz`. 
     `TANGRAM = https://github.com/tangrams/tangram-docs/archive/gh-pages.tar.gz`
-
-    Next, uncompress it, with a line further down in the Makefile that looks something like this:
-
+- It uncompresses the file, with a line further down in the Makefile that looks something like this. This will extract the files into the `src/project-name` directory, which makes them available to mkdocs. 
     `curl -sL $(TANGRAM) | tar -zxv -C src-tangram --strip-components=2 tangram-docs-gh-pages/pages`
-
-    This will extract the files into the `src/project-name` directory, which makes them available to mkdocs. 
-
-    You can also change the branch used as the source of the documentation with these lines, which can be handy for testing purposes. This is accomplished by replacing `gh-pages` with the name of another branch. Note that you'll need to convert any slashes in the branch name to dashes – e.g. if your repo name is `tangram-docs` and your branch name is `meetar/cleanup`, the reference in the `curl` command will look like `tangram-docs-meetar-cleanup`, and the full command will be:
-
-    `curl -sL $(TANGRAM) | tar -zxv -C src-tangram --strip-components=2 tangram-docs-meetar-cleanup/pages`
-
-3. **Create redirects if necessary.** Sometimes you have to change names for the files or move files into other folders, or you delete a file. You should make a redirect link so users can find the new topic.
-To create a redirect, under the `pages` section of the product's config .yml, add another section called 'mz:redirects'. In this section, add the original markdown file name that you have moved, and then add the page where it should be redirected. Take this example from the `search.yml`, for instance:
-
-    `mz:redirects:
-      'get-started': '.'
-      'transition-from-beta': '.'``
-      
-If you need to create a different path in the documentation output than the file name or folder system, consider whether you should make these changes in the GitHub repository first.
-
-## Documentation writing instructions
-
-Follow the guidelines of the [writing style guide](https://github.com/mapzen/styleguide/tree/master/src/site/guides) when it comes to writing technical documentation.
+    
+You can use this line to change the branch used as the source of the documentation with these lines, which can be handy for testing purposes. This is accomplished by replacing `gh-pages` with the name of another branch. Note that you'll need to convert any slashes in the branch name to dashes. For example, if your repo name is `tangram-docs` and your branch name is `cleanup`, the reference in the `curl` command will look like `tangram-docs-cleanup`, and the full command will be:
+    `curl -sL $(TANGRAM) | tar -zxv -C src-tangram --strip-components=2 tangram-docs-cleanup/pages`

--- a/SETUP.md
+++ b/SETUP.md
@@ -1,20 +1,33 @@
-## Making MkDocs happy
+# Set up and documentation update instructions
 
-### You must always:
+## Follow MkDocs requirements
 
 - Include an `index.md` file at the root folder of your documentation. (Note: [MkDocs will allow this to be customized in the future.](https://github.com/mkdocs/mkdocs/issues/608))
 - Include all local documentation assets, such as images, inside this root folder (or link to an external source).
-- Start each page with a top-level heading. (Note: The level of heading should no longer affect presentation, but I still need to test whether this affects TOC creation.)
+- Start each page with a top-level heading with one `#` symbol, except for the index.md. The home page should not have a title because it would most likely duplicate the banner on the page.
 
-### Markdown formatting tweaks for compatibility with GitHub
+### Preview the changes on the precog website
 
-- Blank lines between different blocks of content will be your best friend(s). So, include a blank line before and after bulleted lists, numbered lists, code blocks, images...
+If you've created a Pull Request in the mapzen-docs-generator repository, you can view changes in Precog at [precog.mapzen.com/mapzen/mapzen-docs-generator/](precog.mapzen.com/mapzen/mapzen-docs-generator/). This will only show changes that have been done in this specific repository. If the changes you're doing on a particular repository aren't live yet, you need to edit the **Makefile** to reflect the branch that you're working on. You can do this by:
+
+1. Opening the Makefile
+2. In another tab, open the latest commit on the branch you're working on in the particular project repository
+3. Copy the full commit ID
+4. In the mapzen-docs-generator Makefile, edit the URL and replace the phrase (typically 'master') before .tar.gz with the commit ID, for example:
+
+`EXTRACTS = https://github.com/mapzen/metro-extracts/archive/master.tar.gz --> EXTRACTS = https://github.com/mapzen/metro-extracts/archive/2d3ef32e1a6fc51be6908968e32902a04a016dee.tar.gz`
+
+At the moment, this will be needed to be updated with the new commit ID when needed.
+
+## Make your markdown compatible with GitHub and the documentation site
+
+- [Markdown formatting guide](https://github.com/adam-p/markdown-here/wiki/Markdown-Cheatsheet)
+- Add blank lines between different blocks of content: before and after bulleted lists, numbered lists, code blocks, images, and so on.
 - If a code block or image is supposed to be part of a list, remember the blank lines before and after, and _also_ indent it **four spaces**. Using or mixing tabs might cause problems. Python Markdown is a lot pickier about this than GitHub-flavored Markdown, causing lists to nest improperly or break numbering altogether.
-- Good luck!
 
-## Updating documentation sources
+## Update the documentation source file
 
-There are two things to do if you want to change the GitHub source of documentation.
+There are two (sometimes three) things to do if you want to change the GitHub source of documentation.
 
 1. **Update the project configuration file.** This is located at `config/project-name.yml` file. Look for the `extra` key and find or create, one level in, the `docs_base_url` key. This is used to build the "edit in GitHub" links at the bottom of each page. The actual path and file name are appended to the base URL. It will look something like this:
 
@@ -23,16 +36,29 @@ There are two things to do if you want to change the GitHub source of documentat
       docs_base_url: https://github.com/mapzen/mapzen-docs/tree/master/metro-extracts
     ```
 
-2. **Update the repository path in the Makefile.** The Makefile is located in this repo's root, and is called `Makefile`. This step is a little harder and benefits from some knowledge of shell scripting and `Make`. Generally, we want to first retrieve the source documentation file, which is available from GitHub inside a pre-packaged archive with the extension `tar.gz`. We locate it by setting a variable with the file's location, which might look something like this:
+2. **Update the repository path in the Makefile.** The Makefile is located in this repo's root, and is called `Makefile`. This step is a little harder and benefits from some knowledge of shell scripting and `Make`. Generally, you want to first retrieve the source documentation file, which is available from GitHub inside a pre-packaged archive with the extension `tar.gz`. You locate it by setting a variable with the file's location, which might look something like this:
 
     `TANGRAM = https://github.com/tangrams/tangram-docs/archive/gh-pages.tar.gz`
-    
-    Next, we uncompress it, with a line further down in the Makefile that looks something like this:
-    
+
+    Next, uncompress it, with a line further down in the Makefile that looks something like this:
+
     `curl -sL $(TANGRAM) | tar -zxv -C src-tangram --strip-components=2 tangram-docs-gh-pages/pages`
-    
-    This will extract the files into the `src/project-name` directory, which makes them available to mkdocs. If you're getting files from the `mapzen-docs` repository, you will have to flatten the directory structure a level up because of how the repository is organized. This step can vary depending on the project, which is why it's not super friendly.
+
+    This will extract the files into the `src/project-name` directory, which makes them available to mkdocs. 
 
     You can also change the branch used as the source of the documentation with these lines, which can be handy for testing purposes. This is accomplished by replacing `gh-pages` with the name of another branch. Note that you'll need to convert any slashes in the branch name to dashes – e.g. if your repo name is `tangram-docs` and your branch name is `meetar/cleanup`, the reference in the `curl` command will look like `tangram-docs-meetar-cleanup`, and the full command will be:
-    
+
     `curl -sL $(TANGRAM) | tar -zxv -C src-tangram --strip-components=2 tangram-docs-meetar-cleanup/pages`
+
+3. **Create redirects if necessary.** Sometimes you have to change names for the files or move files into other folders, or you delete a file. You should make a redirect link so users can find the new topic.
+To create a redirect, under the `pages` section of the product's config .yml, add another section called 'mz:redirects'. In this section, add the original markdown file name that you have moved, and then add the page where it should be redirected. Take this example from the `search.yml`, for instance:
+
+    `mz:redirects:
+      'get-started': '.'
+      'transition-from-beta': '.'``
+      
+If you need to create a different path in the documentation output than the file name or folder system, consider whether you should make these changes in the GitHub repository first.
+
+## Documentation writing instructions
+
+Follow the guidelines of the [writing style guide](https://github.com/mapzen/styleguide/tree/master/src/site/guides) when it comes to writing technical documentation.


### PR DESCRIPTION
This integrates changes from #210 and resolves #220, which reconciles the content in the styleguide repository. I will remove/redirect the file in the styleguide to point here.

SETUP.MD is probably not the right word here, as this file is more on how to build and update docs but it's good enough for now while we do this file reorganization. 

I put the list of content sources in the readme because it seemed like the most relevant content and would help people find the doc files if they came upon this repo and thought it would have all the docs. Mostly, though, we want to direct them to mapzen.com for docs.

Fixes #220 