### PR TITLE
Change the Android docs to use a release

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ VALHALLA = https://github.com/valhalla/valhalla-docs/archive/master.tar.gz
 VECTOR_TILES = https://api.github.com/repos/tilezen/vector-datasource/releases/latest
 TERRAIN_TILES = https://api.github.com/repos/tilezen/joerd/releases/latest
 SEARCH = https://github.com/pelias/pelias-doc/archive/master.tar.gz
-ANDROID = https://github.com/mapzen/android/archive/master.tar.gz
+ANDROID = https://api.github.com/repos/mapzen/android/releases/latest
 IOS = https://github.com/mapzen/ios/archive/master.tar.gz
 MAPZENJS = https://mapzen.com/js/docs.tar.gz
 LIBPOSTAL = https://github.com/whosonfirst/go-whosonfirst-libpostal/archive/master.tar.gz
@@ -74,7 +74,13 @@ src-search:
 
 src-android:
 	mkdir src-android
-	curl -sL $(ANDROID) | tar -zxv -C src-android --strip-components=2 android-master/docs
+	# Try with --wildcards for GNU tar, but fall back to BSD tar syntax for Mac.
+	curl -sL $(ANDROID) \
+	| ./extract-tarball-url.py \
+	| xargs curl -sL | ( \
+	    tar -zxv -C src-android --strip-components=2 --exclude=README.md --wildcards '*/docs/' \
+	 || tar -zxv -C src-android --strip-components=2 --exclude=README.md '*/docs/' \
+	    )
 
 src-ios:
 	mkdir src-ios

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ VECTOR_TILES = https://api.github.com/repos/tilezen/vector-datasource/releases/l
 TERRAIN_TILES = https://api.github.com/repos/tilezen/joerd/releases/latest
 SEARCH = https://github.com/pelias/pelias-doc/archive/master.tar.gz
 ANDROID = https://api.github.com/repos/mapzen/android/releases/latest
-IOS = https://github.com/mapzen/ios/archive/master.tar.gz
+IOS = https://api.github.com/repos/mapzen/ios/releases/latest
 MAPZENJS = https://mapzen.com/js/docs.tar.gz
 LIBPOSTAL = https://github.com/whosonfirst/go-whosonfirst-libpostal/archive/master.tar.gz
 CARTOGRAPHY = https://github.com/tangrams/cartography-docs/archive/master.tar.gz
@@ -84,7 +84,13 @@ src-android:
 
 src-ios:
 	mkdir src-ios
-	curl -sL $(IOS) | tar -zxv -C src-ios --strip-components=2 ios-master/docs
+	# Try with --wildcards for GNU tar, but fall back to BSD tar syntax for Mac.
+	curl -sL $(IOS) \
+	| ./extract-tarball-url.py \
+	| xargs curl -sL | ( \
+	    tar -zxv -C src-ios --strip-components=2 --exclude=README.md --wildcards '*/docs/' \
+	 || tar -zxv -C src-ios --strip-components=2 --exclude=README.md '*/docs/' \
+	    )
 
 src-mapzen-js:
 	mkdir src-mapzen-js

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ The source files to build Mapzen's documentation may be found in separate docume
 | [Terrain tiles](https://mapzen.com/documentation/terrain-tiles/)  | https://github.com/tilezen/joerd  | Latest release  |
 | [Elevation](https://mapzen.com/documentation/elevation/) | https://github.com/valhalla/valhalla-docs  | Master |
 | [Android SDK](https://mapzen.com/documentation/android/) | https://github.com/mapzen/android/tree/master/docs | Latest release |
-| [iOS SDK](https://mapzen.com/documentation/ios/) | https://github.com/mapzen/ios/blob/master/docs | Master |
+| [iOS SDK](https://mapzen.com/documentation/ios/) | https://github.com/mapzen/ios/blob/master/docs | Latest release |
 | [Address parsing/libpostal](https://mapzen.com/documentation/libpostal/) | https://github.com/whosonfirst/go-whosonfirst-libpostal/blob/master/docs | Master |
 | [Cartography](https://mapzen.com/documentation/cartography/) | https://github.com/tangrams/cartography-docs/ | Master |
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ The source files to build Mapzen's documentation may be found in separate docume
 | [Metro Extracts](https://mapzen.com/documentation/metro-extracts/)  | https://github.com/mapzen/metro-extracts/tree/master/docs  | Master |
 | [Terrain tiles](https://mapzen.com/documentation/terrain-tiles/)  | https://github.com/tilezen/joerd  | Latest release  |
 | [Elevation](https://mapzen.com/documentation/elevation/) | https://github.com/valhalla/valhalla-docs  | Master |
-| [Android SDK](https://mapzen.com/documentation/android/) | https://github.com/mapzen/android/tree/master/docs | Master |
+| [Android SDK](https://mapzen.com/documentation/android/) | https://github.com/mapzen/android/tree/master/docs | Latest release |
 | [iOS SDK](https://mapzen.com/documentation/ios/) | https://github.com/mapzen/ios/blob/master/docs | Master |
 | [Address parsing/libpostal](https://mapzen.com/documentation/libpostal/) | https://github.com/whosonfirst/go-whosonfirst-libpostal/blob/master/docs | Master |
 | [Cartography](https://mapzen.com/documentation/cartography/) | https://github.com/tangrams/cartography-docs/ | Master |


### PR DESCRIPTION
This makes the Android docs use a release, rather than a master source.

I copied the build steps for tiles, which should be done the same way, and it appears to be working: https://precog.mapzen.com/mapzen/documentation/rhonda-android-release/documentation/android/

I wasn't able to get iOS working like this because it's in a prerelease state in GitHub, but I can continue poking at GitHub's API...

cc @ecgreb - I don't think there is anything you need to do in the Android repo, other than be sure to move your docs into the release when you want them published...but we need to test!