### PR TITLE
Meetar/fix tutorials

### DIFF
--- a/config/tangram.yml
+++ b/config/tangram.yml
@@ -7,18 +7,18 @@ site_dir: dist-tangram
 # This means pages should be added or subtracted manually here if the files change.
 pages:
   - Home: index.md
-  - Concept Overviews:
+  - Concept overviews:
     - 'Tangram': 'Tangram-Overview.md'
-    - 'The Scene File': 'Scene-file.md'
-    - 'Data Filters': 'Filters-Overview.md'
+    - 'The scene file': 'Scene-file.md'
+    - 'Data filters': 'Filters-Overview.md'
     - 'Styles': 'Styles-Overview.md'
     - 'Shaders': 'Shaders-Overview.md'
-    - 'Raster Sources': 'Raster-Overview.md'
+    - 'Raster sources': 'Raster-Overview.md'
     - 'Lights': 'Lights-Overview.md'
     - 'Cameras': 'Cameras-Overview.md'
     - 'Materials': 'Materials-Overview.md'
     - 'YAML': 'yaml.md'
-  - Syntax Reference:
+  - Syntax reference:
     - 'cameras': 'cameras.md'
     - 'draw': 'draw.md'
     - 'global': 'global.md'
@@ -32,14 +32,14 @@ pages:
     - 'sources': 'sources.md'
     - 'styles': 'styles.md'
     - 'textures': 'textures.md'
-  - Get Started:
-    - Setup Guides: 
-      - 'Setup Overview': 'Tangram-Setup.md'
-      - 'JS Walkthrough': 'walkthrough.md'
-      - 'Android Walkthrough': 'android-walkthrough.md'
+  - Get started:
+    - Setup guides: 
+      - 'Setup overview': 'Tangram-Setup.md'
+      - 'JS walkthrough': 'walkthrough.md'
+      - 'Android walkthrough': 'android-walkthrough.md'
     - Tutorials:
-      - 'Custom Styles': 'tutorials/custom-styles.md'
-      - 'Editing Basemaps': 'tutorials/editing-basemaps.md'
+      - 'Custom styles': 'tutorials/custom-styles.md'
+      - 'Editing basemaps': 'tutorials/editing-basemaps.md'
     - 'Demos': 'demos.md'
   - JavaScript API: 'Javascript-API.md'
   - Android API: 'Android-API.md'

--- a/config/tangram.yml
+++ b/config/tangram.yml
@@ -32,17 +32,18 @@ pages:
     - 'sources': 'sources.md'
     - 'styles': 'styles.md'
     - 'textures': 'textures.md'
-  - JavaScript API: 'Javascript-API.md'
-  - Android API: 'Android-API.md'
-  - iOS API: 'iOS-API.md'
   - Get Started:
-    - 'Setup Guides': 'Tangram-Setup.md'
-    - 'JS Walkthrough': 'walkthrough.md'
-    - 'Android Walkthrough': 'android-walkthrough.md'
+    - Setup Guides: 
+      - 'Setup Overview': 'Tangram-Setup.md'
+      - 'JS Walkthrough': 'walkthrough.md'
+      - 'Android Walkthrough': 'android-walkthrough.md'
     - Tutorials:
       - 'Custom Styles': 'tutorials/custom-styles.md'
       - 'Editing Basemaps': 'tutorials/editing-basemaps.md'
     - 'Demos': 'demos.md'
+  - JavaScript API: 'Javascript-API.md'
+  - Android API: 'Android-API.md'
+  - iOS API: 'iOS-API.md'
 
 # Determines if a broken link to a page within the documentation is considered
 # a warning or an error (link to a page not listed in the pages setting). Set

--- a/config/tangram.yml
+++ b/config/tangram.yml
@@ -37,11 +37,12 @@ pages:
   - iOS API: 'iOS-API.md'
   - Get Started:
     - 'Setup Guides': 'Tangram-Setup.md'
-    - 'Demos': 'demos.md'
     - 'JS Walkthrough': 'walkthrough.md'
     - 'Android Walkthrough': 'android-walkthrough.md'
-    - 'Custom Styles': 'tutorials/custom-styles.md'
-    - 'Editing Basemaps': 'tutorials/editing-basemaps.md'
+    - Tutorials:
+      - 'Custom Styles': 'tutorials/custom-styles.md'
+      - 'Editing Basemaps': 'tutorials/editing-basemaps.md'
+    - 'Demos': 'demos.md'
 
 # Determines if a broken link to a page within the documentation is considered
 # a warning or an error (link to a page not listed in the pages setting). Set

--- a/config/tangram.yml
+++ b/config/tangram.yml
@@ -36,6 +36,7 @@ pages:
   - Android API: 'Android-API.md'
   - iOS API: 'iOS-API.md'
   - Get Started:
+    - 'Setup Guides': 'Tangram-Setup.md'
     - 'Demos': 'demos.md'
     - 'JS Walkthrough': 'walkthrough.md'
     - 'Android Walkthrough': 'android-walkthrough.md'

--- a/config/tangram.yml
+++ b/config/tangram.yml
@@ -36,9 +36,11 @@ pages:
   - Android API: 'Android-API.md'
   - iOS API: 'iOS-API.md'
   - Get Started:
-    - 'Setup Guides': 'Tangram-Setup.md'
-    - 'Tutorials & Demos': 'demos.md'
-
+    - 'Demos': 'demos.md'
+    - 'JS Walkthrough': 'walkthrough.md'
+    - 'Android Walkthrough': 'android-walkthrough.md'
+    - 'Custom Styles': 'tutorials/custom-styles.md'
+    - 'Editing Basemaps': 'tutorials/editing-basemaps.md'
 
 # Determines if a broken link to a page within the documentation is considered
 # a warning or an error (link to a page not listed in the pages setting). Set


### PR DESCRIPTION
Turns out pages won't be built unless they are listed in the config hierarchy, which is also used to build the sidebar, which means every page must have an entry in the sidebar.

Ideally the page-building mechanism and the sidebar-building mechanism would be separable, and we'd be able to structure the sidebar in the way that best organizes the content – but we can just move the tutorials here for now.