### PR TITLE
Update category-titles from h6 to h3

### DIFF
--- a/src-index/index.md
+++ b/src-index/index.md
@@ -29,9 +29,9 @@
 	</div>
 	<div class="row">
 		<div class="col-xs-12 footroom-large">
-			<h6 class="category-title">
+			<h3 class="category-title">
 				Maps
-			</h6>
+			</h3>
 			<div class="category-info-container first">
 				<div class="category-info">
 					<a class="docs-title" href="mapzen-js/">mapzen.js</a>
@@ -89,9 +89,9 @@
 			</div>
 		</div>
 		<div class="col-xs-12 footroom-large">
-			<h6 class="category-title">
+			<h3 class="category-title">
 				Search & Mobility
-			</h6>
+			</h3>
 			<div class="category-info-container first">
 				<div class="category-info">
 					<a class="docs-title" href="search/">Mapzen Search</a>
@@ -116,9 +116,9 @@
 			</div>
 		</div>
 		<div class="col-xs-12 footroom-large">
-			<h6 class="category-title">
+			<h3 class="category-title">
 				Data
-			</h6>
+			</h3>
 			<div class="category-info-container first">
 				<div class="category-info">
 					<a class="docs-title" href="metro-extracts/">Metro Extracts</a>
@@ -154,9 +154,9 @@
 			</div>
 		</div>
 		<div class="col-xs-12 footroom-large">
-			<h6 class="category-title">
+			<h3 class="category-title">
 				Mobile
-			</h6>
+			</h3>
 			<div class="category-info-container first">
 				<div class="category-info">
 					<a class="docs-title" href="android/">Android SDK</a>


### PR DESCRIPTION
Update category-titles from h6 to h3 to match new styleguide format.  Part of https://github.com/mapzen/website/issues/1413