### PR TITLE
Remove part of account rollout note

### DIFF
--- a/docs/overview/account-settings.md
+++ b/docs/overview/account-settings.md
@@ -1,6 +1,6 @@
 # Update your Mapzen account settings
 
-_Note: You may not see all billing and account settings options right now while your account is being upgraded. The rate limit and pricing information presented here will be fully effective for all accounts starting June 1, 2017._
+_Note: The rate limit and pricing information presented here will be fully effective for all accounts starting June 1, 2017._
 
 When you signed in on Mapzen’s website, you can view and modify your account settings. These include changing your email address and password, and updating your credit card and billing information.
 

--- a/docs/overview/billing.md
+++ b/docs/overview/billing.md
@@ -14,6 +14,8 @@ The billing currency is the United States Dollar (USD). Mapzen handles the payme
 
 If you need to update your credit card information, you can do that from your [Mapzen account settings](account-settings.md#add-your-payment-method). If you have questions about your bill or are having problems paying it, please contact Mapzen at support@mapzen.com.
 
+Rate limits are reset on the first day of every month at 00:00 UTC (Coordinated Universal Time).
+
 ## View your usage
 
 To check your usage, sign in to your developer account and review your dashboard.

--- a/docs/overview/billing.md
+++ b/docs/overview/billing.md
@@ -1,6 +1,6 @@
 # View your current usage and bill
 
-_Note: You may not see all billing and account settings options right now while your account is being upgraded. The rate limit and pricing information presented here will be fully effective for all accounts starting June 1, 2017._
+_Note: The rate limit and pricing information presented here will be fully effective for all accounts starting June 1, 2017._
 
 When you are signed in with your Mapzen account, you can view your current usage and charges due.
 

--- a/docs/overview/rate-limits.md
+++ b/docs/overview/rate-limits.md
@@ -1,6 +1,6 @@
 # Rate limits
 
-_Note: You may not see all billing and account settings options right now while your account is being upgraded. The rate limit and pricing information presented here will be fully effective for all accounts starting June 1, 2017._
+_Note: The rate limit and pricing information presented here will be fully effective for all accounts starting June 1, 2017._
 
 Mapzen offers some level of free access to each service, subject to rate limits. The services have maximum numbers of requests you can make per month, and some have additional service limitations to minimize computationally intensive uses.
 


### PR DESCRIPTION
All accounts now have the billing and account settings options. 

Also adds a note to the rate limits page that says when rate limits reset (previously, only on the account settings documentation page)