### PR TITLE
Search docs: remove API keys page and add redirect

### DIFF
--- a/config/search.yml
+++ b/config/search.yml
@@ -16,12 +16,12 @@ pages:
   - 'HTTP status codes': 'http-status-codes.md'
   - 'Load data from the browser': 'use-cors.md'
   - 'Tutorial': 'add-search-to-a-map.md'
-  - 'API keys and rate limits': 'api-keys-rate-limits.md'
   - 'Release notes': 'release-notes.md'
 
 mz:redirects:
   'get-started': '.'
   'transition-from-beta': '.'
+  'api-keys-rate-limits.md': '.'
 
 extra:
   site_subtitle: 'Find places and addresses with this geographic search service built on open tools and open data.'


### PR DESCRIPTION
This removes the page about API keys, rate limits, and server caching for search. It adds in a rudimentary redirect to the top of the section (don't think it's feasible to redirect to a topic outside of this section).

Part of fixes for https://github.com/mapzen/documentation/issues/192