### PR TITLE
Remove attribution and API keys pages from tiles

### DIFF
--- a/config/terrain-tiles.yml
+++ b/config/terrain-tiles.yml
@@ -7,9 +7,11 @@ pages:
   - 'Formats': 'formats.md'
   - 'Get started': 'use-service.md'
   - 'Build a map': 'build-a-map.md'
-  - 'Data Sources': 'data-sources.md'
-  - 'Attribution': 'attribution.md'
-  - 'API keys and rate limits': 'api-keys-and-rate-limits.md'
+  - 'Data sources': 'data-sources.md'
+  
+ mz:redirects:
+  'attribution': '.'
+  'api-keys-and-rate-limits': '.'
 
 # Extra variables for templates
 extra:

--- a/config/terrain-tiles.yml
+++ b/config/terrain-tiles.yml
@@ -9,7 +9,7 @@ pages:
   - 'Build a map': 'build-a-map.md'
   - 'Data sources': 'data-sources.md'
   
- mz:redirects:
+mz:redirects:
   'attribution': '.'
   'api-keys-and-rate-limits': '.'
 

--- a/config/vector-tiles.yml
+++ b/config/vector-tiles.yml
@@ -10,7 +10,7 @@ pages:
   - 'Data sources': 'data-sources.md'
   - 'Migrate to version 1.0': 'migrate-to-vector-tiles-v1.md'
   
- mz:redirects:
+mz:redirects:
   'attribution': '.'
   'api-keys-and-rate-limits': '.'
 

--- a/config/vector-tiles.yml
+++ b/config/vector-tiles.yml
@@ -7,10 +7,12 @@ pages:
   - 'Layers': 'layers.md'
   - 'Get started': 'use-service.md'
   - 'Make a map': 'display-tiles.md'
-  - 'Data Sources': 'data-sources.md'
-  - 'Attribution': 'attribution.md'
-  - 'API keys and rate limits': 'api-keys-and-rate-limits.md'
+  - 'Data sources': 'data-sources.md'
   - 'Migrate to version 1.0': 'migrate-to-vector-tiles-v1.md'
+  
+ mz:redirects:
+  'attribution': '.'
+  'api-keys-and-rate-limits': '.'
 
 # Extra variables for templates
 extra:


### PR DESCRIPTION
After chatting with @nvkelso, we're going to remove the attribution and API keys and rate limits pages from both the terrain tiles and vector tiles documentation.

This PR removes them from publishing on mapzen.com and adds redirects to the top of the section (best I can do for now).

The attribution will be maintained in the repos for the open-source projects (and at mapzen.com/rights), but the API keys pages will be deleted completely because they are covered in the Mapzen docs. 

Related:
https://github.com/tilezen/vector-datasource/issues/1237
https://github.com/tilezen/vector-datasource/issues/1236
https://github.com/tilezen/joerd/issues/142
https://github.com/tilezen/joerd/issues/141