### PR TITLE
Add Mobility Explorer tutorial to table of contents

### DIFF
--- a/config/mobility.yml
+++ b/config/mobility.yml
@@ -31,6 +31,7 @@ pages:
     - 'Overview': 'explorer/overview.md'
     - 'Explore transit': 'explorer/explore-transit.md'
     - 'Generate isochrones': 'explorer/isochrones.md'
+    - 'Tutorial': 'explorer/tutorial.md'
   - 'Decode a route shape': 'decoding.md'
   - 'Release notes': 'release-notes.md'
 


### PR DESCRIPTION
This adds the Mobility Explorer tutorial to the help system. 

Depends on https://github.com/valhalla/valhalla-docs/pull/168 being merged first.