### PR TITLE
[Do not merge yet] Add premium support section and updates

### DIFF
--- a/docs/overview/account-settings.md
+++ b/docs/overview/account-settings.md
@@ -73,13 +73,17 @@ Anytime you want to start billing again, set your billing status to `Enabled`.
 
 ## Enable premium support		
 
-Premium support, which includes faster response times and a service-level agreement, is available for an additional [monthly fee](https://mapzen.com/pricing/#premium-support). When contacting Mapzen, users with premium support receive priority replies. A service-level agreement indicates the service's required uptime and instructions to take if these are not met. You can add premium support even if you are within the free rate limits of Mapzen’s products.
+Premium support, which includes faster response times and a service-level agreement, is available for an additional [monthly fee](https://mapzen.com/pricing/#premium-support). You can add premium support even if you are within the free rate limits of Mapzen’s products.
+
+When contacting Mapzen, users with premium support receive priority replies. Premium support benefits are available to anyone at your organization, not just an individual account.
+
+A service-level agreement indicates the service's required uptime and instructions to take if these are not met. These are detailed in the Mapzen [Terms of Service](https://mapzen.com/terms/).
 
 [Learn more about Mapzen support offerings](support)
 
 You are billed for premium support at the beginning of each month. You can use it as soon as you enable it on your account, and the fee is prorated when joining in the middle of a billing cycle.
 
-If you decide to end your premium support access, you can continue to use your benefits through the end of the month and your credit card will not be charged in subsequent months. No refunds are issued for the remainder of the billing period in which you disable premium support.
+If you choose to disable your premium support access, you can continue to use your benefits through the end of the month and your credit card will not be charged in subsequent months. No refunds are issued for the remainder of the billing period.
 
 _Note: Premium support is for assistance with Mapzen's hosted web services and does not include help for on-premises installations of Mapzen's open-source projects. If you need help running your own instance, there are [community-based options](support.md#github-and-community-chat)._
 

--- a/docs/overview/account-settings.md
+++ b/docs/overview/account-settings.md
@@ -70,3 +70,22 @@ To stop billing, set your billing status to disabled in the `Billing` section of
 Any charges that were pending before you disabled billing will still be charged to the credit card on file at the end of the current billing cycle. However, no further charges can accrue. The billing status remains as you set it until you change it in the future.
 
 Anytime you want to start billing again, set your billing status to `Enabled`.
+
+## Enable premium support		
+
+Premium support, which includes faster response times and a service-level agreement, is available for an additional [monthly fee](https://mapzen.com/pricing/#premium-support)). When contacting Mapzen, users with premium support receive priority replies. A service-level agreement indicates the service's required uptime and instructions to take if these are not met.
+
+You are billed for premium support at the beginning of each month. You can use it as soon as you enable it on your account, and the fee is prorated when joining in the middle of a billing cycle.
+
+If you decide to end your premium support access, you can continue to use your benefits through the end of the month and your credit card will not be charged in subsequent months. No refunds are issued for the remainder of the billing period in which you disable premium support.
+
+You can add premium support even if you are within the free rate limits of Mapzen’s products.
+
+[Learn more about Mapzen support offerings](support)
+
+_Note: Premium support is for assistance with Mapzen's hosted web services and does not include help for on-premises installations of Mapzen's open-source projects. If you need help running your own instance, there are [community-based options](support.md/#github-and-community-chat)._
+
+1. Sign in to your Mapzen account.		
+2. In the top corner of the page, click `Account` and click `Settings`.		
+3. Under `Support`, click `Enable` and agree to the terms.		
+4. To end premium support, under `Support`, click `Update` and disable it on your account.

--- a/docs/overview/account-settings.md
+++ b/docs/overview/account-settings.md
@@ -83,9 +83,9 @@ You can add premium support even if you are within the free rate limits of Mapze
 
 [Learn more about Mapzen support offerings](support)
 
-_Note: Premium support is for assistance with Mapzen's hosted web services and does not include help for on-premises installations of Mapzen's open-source projects. If you need help running your own instance, there are [community-based options](support.md/#github-and-community-chat)._
-
 1. Sign in to your Mapzen account.		
 2. In the top corner of the page, click `Account` and click `Settings`.		
 3. Under `Support`, click `Enable` and agree to the terms.		
 4. To end premium support, under `Support`, click `Update` and disable it on your account.
+
+_Note: Premium support is for assistance with Mapzen's hosted web services and does not include help for on-premises installations of Mapzen's open-source projects. If you need help running your own instance, there are [community-based options](support.md#github-and-community-chat)._

--- a/docs/overview/account-settings.md
+++ b/docs/overview/account-settings.md
@@ -73,19 +73,17 @@ Anytime you want to start billing again, set your billing status to `Enabled`.
 
 ## Enable premium support		
 
-Premium support, which includes faster response times and a service-level agreement, is available for an additional [monthly fee](https://mapzen.com/pricing/#premium-support)). When contacting Mapzen, users with premium support receive priority replies. A service-level agreement indicates the service's required uptime and instructions to take if these are not met.
+Premium support, which includes faster response times and a service-level agreement, is available for an additional [monthly fee](https://mapzen.com/pricing/#premium-support). When contacting Mapzen, users with premium support receive priority replies. A service-level agreement indicates the service's required uptime and instructions to take if these are not met. You can add premium support even if you are within the free rate limits of Mapzen’s products.
+
+[Learn more about Mapzen support offerings](support)
 
 You are billed for premium support at the beginning of each month. You can use it as soon as you enable it on your account, and the fee is prorated when joining in the middle of a billing cycle.
 
 If you decide to end your premium support access, you can continue to use your benefits through the end of the month and your credit card will not be charged in subsequent months. No refunds are issued for the remainder of the billing period in which you disable premium support.
 
-You can add premium support even if you are within the free rate limits of Mapzen’s products.
-
-[Learn more about Mapzen support offerings](support)
+_Note: Premium support is for assistance with Mapzen's hosted web services and does not include help for on-premises installations of Mapzen's open-source projects. If you need help running your own instance, there are [community-based options](support.md#github-and-community-chat)._
 
 1. Sign in to your Mapzen account.		
 2. In the top corner of the page, click `Account` and click `Settings`.		
 3. Under `Support`, click `Enable` and agree to the terms.		
 4. To end premium support, under `Support`, click `Update` and disable it on your account.
-
-_Note: Premium support is for assistance with Mapzen's hosted web services and does not include help for on-premises installations of Mapzen's open-source projects. If you need help running your own instance, there are [community-based options](support.md#github-and-community-chat)._

--- a/docs/overview/billing.md
+++ b/docs/overview/billing.md
@@ -26,9 +26,9 @@ To check your usage, sign in to your developer account and review your dashboard
 
 ## Request a bill credit for service issues
 
-_Note: This is only available to users who subscribe to premium support, which includes a service-level agreement._
+_Note: This is only available to users who purchase [premium support](account-settings.md#enable-premium-support), which includes a service-level agreement._
 
 While Mapzen hopes you never experience an outage or downtime in services, you can request a credit in the event that issues occur. See the Mapzen [Terms of Service](https://mapzen.com/terms/) for more information about your rights and requirements, and keep in mind that those terms supersede any documentation content here.
 
-1. If you are a premium support subscriber and believe that Mapzen has not met the uptime percentage in the developer agreement, record any information about the downtime you can, such as the service name and API, date and time, and estimated outage amount.
+1. If you have [premium support](account-settings.md#enable-premium-support) enabled on your account and believe that Mapzen has not met the uptime percentage in the terms of service, record any information about the downtime you can, such as the service name and API, date and time, and estimated outage amount.
 2. Within 15 days, send this to [Mapzen support](mailto:hello@mapzen.com) for review.

--- a/docs/overview/billing.md
+++ b/docs/overview/billing.md
@@ -26,7 +26,7 @@ To check your usage, sign in to your developer account and review your dashboard
 
 ## Request a bill credit for service issues
 
-_Note: This is only available to users who purchase [premium support](account-settings.md#enable-premium-support), which includes a service-level agreement._
+_Note: This is only available to users who enable [premium support](account-settings.md#enable-premium-support), which includes a service-level agreement._
 
 While Mapzen hopes you never experience an outage or downtime in services, you can request a credit in the event that issues occur. See the Mapzen [Terms of Service](https://mapzen.com/terms/) for more information about your rights and requirements, and keep in mind that those terms supersede any documentation content here.
 

--- a/docs/overview/support.md
+++ b/docs/overview/support.md
@@ -2,7 +2,7 @@
 
 Mapzen has many ways for you to get more help, and wants to hear from you. You can send a note about your bill, bugs or unexpected results, enhancement requests for future development, projects you have built with Mapzen, or any other questions you might have.
 
-All Mapzen users have access to standard email support. Premium support with a service-level agreement is available for an additional monthly fee, and you can subscribe even if you are within the free rate limits of Mapzen’s products. Premium support users receive priority response times, usually within one business day. To sign up for premium support, [contact Mapzen](support@mapzen.com).
+All users of Mapzen services have access to standard email support. Premium support with a service-level agreement is available for an additional [monthly fee](https://mapzen.com/pricing/#premium-support), and you can subscribe even if you are within the free rate limits of Mapzen’s products. Premium support users receive priority response times, usually within one business day. You can enable [premium support](account-settings.md#enable-premium-support) in your account settings.
 
 ## Read documentation and blog posts
 


### PR DESCRIPTION
NOTE: This should not be merged until the functionality is on the production server.

This adds a section for enabling premium support in your account settings and replaces any use of "contact us" to buy it. It also adds links to the pricing page, which lists the fee. @souperneon, please have a look! I've generally used "enable" and "disable", but added a few other synonyms because people might think of those terms, too. 

I've also added some language about whether paid support includes on-premises installation help, given some questions about that recently. @mjcunningham, see if that's reasonable to include. 