### PR TITLE
Add language codes topic to search help

### DIFF
--- a/config/search.yml
+++ b/config/search.yml
@@ -13,6 +13,7 @@ pages:
   - 'Addresses': 'addresses.md'
   - 'API responses': 'response.md'
   - 'Data sources': 'data-sources.md'
+  - 'Languages': 'language-codes.md'
   - 'HTTP status codes': 'http-status-codes.md'
   - 'Load data from the browser': 'use-cors.md'
   - 'Tutorial': 'add-search-to-a-map.md'


### PR DESCRIPTION
This adds a new file about language support to the published search help on mapzen.com.

cc @dianashk @missinglink