### PR TITLE
Add map-matching topics to help for release

### DIFF
--- a/config/mobility.yml
+++ b/config/mobility.yml
@@ -27,10 +27,12 @@ pages:
   - 'Optimized route': 'optimized/api-reference.md'
   - 'Time-Distance Matrix': 'matrix/api-reference.md'
   - 'Isochrone': 'isochrone/api-reference.md'
+  - 'Map Matching': 'map-matching/api-reference.md'
   - 'Mobility Explorer':
     - 'Overview': 'explorer/overview.md'
     - 'Explore transit': 'explorer/explore-transit.md'
     - 'Generate isochrones': 'explorer/isochrones.md'
+    - 'Match GPS locations to a route': 'explorer/map-matching.md'
     - 'Tutorial': 'explorer/tutorial.md'
   - 'Decode a route shape': 'decoding.md'
   - 'Release notes': 'release-notes.md'
@@ -39,6 +41,8 @@ mz:redirects:
   'turn-by-turn': 'turn-by-turn/api-reference'
   'matrix': 'matrix/api-reference'
   'optimized': 'optimized/api-reference'
+  'isochrone': 'isochrone/api-reference.md'
+  'map-matching': 'map-matching/api-reference.md'
 
 extra:
   site_subtitle: 'Add routing and navigation to your web and mobile apps.'

--- a/docs/overview/rate-limits.md
+++ b/docs/overview/rate-limits.md
@@ -86,7 +86,7 @@ The distance limit is the total straight-line distance (colloquially, as the cro
 - The maximum time to compute isochrone contours from the location is 120 minutes.
 - The maximum number of isochrone contours in a single request is four.
 
-#### Mapzen Map Matching
+### Mapzen Map Matching
 
 [Mapzen Map Matching](https://mapzen.com/documentation/mobility/map-matching/api-reference/) matches coordinates to known roads so you can turn a path into a route with narrative instructions and get the attribute values from that matched line. The service has these limits:
 

--- a/docs/overview/rate-limits.md
+++ b/docs/overview/rate-limits.md
@@ -86,7 +86,17 @@ The distance limit is the total straight-line distance (colloquially, as the cro
 - The maximum time to compute isochrone contours from the location is 120 minutes.
 - The maximum number of isochrone contours in a single request is four.
 
-The Mapzen Turn-by-Turn, Matrix, Optimized Route, and Isochrone services are built from the [Valhalla](https://github.com/valhalla) open-source project.
+#### Mapzen Map Matching
+
+[Mapzen Map Matching](https://mapzen.com/documentation/mobility/map-matching/api-reference/) matches coordinates to known roads so you can turn a path into a route with narrative instructions and get the attribute values from that matched line. The service has these limits:
+
+- 1,000 free requests per month
+- The maximum input shape distance is 200 kilometers when using the `map_snap` shape match and 1,000 kilometers when using the `edge_walk` shape match.
+- The maximum number of input shape points is 16,000.
+- The maximum input GPS accuracy is 100 meters.
+- The maximum upper bounds of the search radius is 100 meters.
+
+The Mapzen Mobility services are built from the [Valhalla](https://github.com/valhalla) open-source project.
 
 ## Data products
 


### PR DESCRIPTION
This adds map matching API reference and Mobility Explorer topics to the help. It also adds the rate limits to the page with the others.

This replaces https://github.com/mapzen/documentation/pull/279, which had gotten pretty out of date.

Do not merge until ready for release. 