### PR TITLE
Add libpostal API rate limits

### DIFF
--- a/docs/overview/rate-limits.md
+++ b/docs/overview/rate-limits.md
@@ -108,6 +108,14 @@ Retrieve data about places from the [Who's On First](https://mapzen.com/document
 
 _Note: This service currently offers only free access with these limits. Mapzen is working on updating this service to allow increased usage._
 
+### Libpostal address parsing
+
+[Libpostal API](https://mapzen.com/documentation/libpostal/) parses and normalizes street addresses and has these limits:
+
+- 30,000 free requests per day
+
+_Note: This service currently offers only free access with these limits. Mapzen is working on updating this service to allow increased usage._
+
 ### Other data products
 
 Mapzen's other data products do not currently require API keys. These include:


### PR DESCRIPTION
These were missing from the rate limits page (a user asked about it), so this adds in the current numbers for when an API key is included with a request.