### PR TITLE
Removing the api keys redirect for old search topic

### DIFF
--- a/config/search.yml
+++ b/config/search.yml
@@ -23,7 +23,6 @@ pages:
 mz:redirects:
   'get-started': '.'
   'transition-from-beta': '.'
-  'api-keys-rate-limits.md': '.'
 
 extra:
   site_subtitle: 'Find places and addresses with this geographic search service built on open tools and open data.'


### PR DESCRIPTION
Something has gone wrong with this redirect.

This makes it go to a 404 for now, rather than show old content.