### PR TITLE
Add new speed documentation to mobility help

### DIFF
--- a/config/mobility.yml
+++ b/config/mobility.yml
@@ -34,8 +34,9 @@ pages:
     - 'Generate isochrones': 'explorer/isochrones.md'
     - 'Match GPS locations to a route': 'explorer/map-matching.md'
     - 'Tutorial': 'explorer/tutorial.md'
-  - 'Speeds': 'speeds.md'
-  - 'Decode a route shape': 'decoding.md'
+  - 'Reference':
+    - 'Speeds': 'speeds.md'
+    - 'Decode a route shape': 'decoding.md'
   - 'Release notes': 'release-notes.md'
 
 mz:redirects:
@@ -44,6 +45,7 @@ mz:redirects:
   'optimized': 'optimized/api-reference'
   'isochrone': 'isochrone/api-reference.md'
   'map-matching': 'map-matching/api-reference.md'
+  'decoding': 'reference/decoding.md'
 
 extra:
   site_subtitle: 'Add routing and navigation to your web and mobile apps.'

--- a/config/mobility.yml
+++ b/config/mobility.yml
@@ -34,6 +34,7 @@ pages:
     - 'Generate isochrones': 'explorer/isochrones.md'
     - 'Match GPS locations to a route': 'explorer/map-matching.md'
     - 'Tutorial': 'explorer/tutorial.md'
+  - 'Speeds': 'speeds.md'
   - 'Decode a route shape': 'decoding.md'
   - 'Release notes': 'release-notes.md'
 

--- a/config/mobility.yml
+++ b/config/mobility.yml
@@ -45,7 +45,6 @@ mz:redirects:
   'optimized': 'optimized/api-reference'
   'isochrone': 'isochrone/api-reference.md'
   'map-matching': 'map-matching/api-reference.md'
-  'decoding': 'reference/decoding.md'
 
 extra:
   site_subtitle: 'Add routing and navigation to your web and mobile apps.'


### PR DESCRIPTION
This adds a new file to the table of contents that discusses how speeds are calculated in the mobility APIs.

This nests under a new heading of Reference, along with decoding and any other related new docs. Nesting like this does not affect the URL, so no redirects are needed for the existing decoding topic.

Preview: https://precog.mapzen.com/mapzen/documentation/rhonda-mobility-speed/documentation/mobility/speeds/

cc @dnesbitt61 - thanks for the docs!