### PR TITLE
Update build process to reflect reorganized mobility content

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,6 @@
 TANGRAM = https://github.com/tangrams/tangram-docs/archive/gh-pages.tar.gz
 EXTRACTS = https://github.com/mapzen/metro-extracts/archive/master.tar.gz
 VALHALLA = https://github.com/valhalla/valhalla-docs/archive/master.tar.gz
-VALHALLA_TEMP = https://github.com/valhalla/valhalla-docs/archive/rhonda-reorg.tar.gz
 VECTOR_TILES = https://api.github.com/repos/tilezen/vector-datasource/releases/latest
 TERRAIN_TILES = https://api.github.com/repos/tilezen/joerd/releases/latest
 SEARCH = https://github.com/pelias/pelias-doc/archive/master.tar.gz
@@ -69,7 +68,7 @@ src-elevation:
 
 src-mobility:
 	mkdir src-mobility
-	curl -sL $(VALHALLA_TEMP) | tar -zxv -C src-mobility --strip-components=1 valhalla-docs-rhonda-reorg
+	curl -sL $(VALHALLA) | tar -zxv -C src-mobility --strip-components=1 valhalla-docs-master
 
 src-search:
 	mkdir src-search

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@
 TANGRAM = https://github.com/tangrams/tangram-docs/archive/gh-pages.tar.gz
 EXTRACTS = https://github.com/mapzen/metro-extracts/archive/master.tar.gz
 VALHALLA = https://github.com/valhalla/valhalla-docs/archive/master.tar.gz
+VALHALLA_TEMP = https://github.com/valhalla/valhalla-docs/archive/rhonda-reorg.tar.gz
 VECTOR_TILES = https://api.github.com/repos/tilezen/vector-datasource/releases/latest
 TERRAIN_TILES = https://api.github.com/repos/tilezen/joerd/releases/latest
 SEARCH = https://github.com/pelias/pelias-doc/archive/master.tar.gz
@@ -68,7 +69,7 @@ src-elevation:
 
 src-mobility:
 	mkdir src-mobility
-	curl -sL $(VALHALLA) | tar -zxv -C src-mobility --strip-components=1 valhalla-docs-master
+	curl -sL $(VALHALLA_TEMP) | tar -zxv -C src-mobility --strip-components=1 valhalla-docs-rhonda-reorg
 
 src-search:
 	mkdir src-search

--- a/config/mobility.yml
+++ b/config/mobility.yml
@@ -2,8 +2,6 @@ site_name: Mapzen Mobility
 docs_dir: src-mobility
 site_dir: dist-mobility
 
-# force rebuild
-
 pages:
   - Home: index.md
   - 'Glossary': 'terminology.md'

--- a/config/mobility.yml
+++ b/config/mobility.yml
@@ -2,17 +2,6 @@ site_name: Mapzen Mobility
 docs_dir: src-mobility
 site_dir: dist-mobility
 
-# # mz:renames:
-#   'images/browser-controls.png': 'turn-by-turn/images/browser-controls.png'
-#   'images/browser-initial-map.png': 'turn-by-turn/images/browser-initial-map.png'
-#   'images/local-browser.png': 'turn-by-turn/images/local-browser.png'
-#   'images/route-map-initial.png': 'turn-by-turn/images/route-map-initial.png'
-#   'images/route-map-valhalla-destination.png': 'turn-by-turn/images/route-map-valhalla-destination.png'
-#   'images/route-map-valhalla-line-color.png': 'turn-by-turn/images/route-map-valhalla-line-color.png'
-#   'images/route-map-valhalla.png': 'turn-by-turn/images/route-map-valhalla.png'
-#   'images/start-python-server.png': 'turn-by-turn/images/start-python-server.png'
-#   'images/terminal-404-error.png': 'turn-by-turn/images/terminal-404-error.png'
-
 pages:
   - Home: index.md
   - 'Glossary': 'terminology.md'

--- a/config/mobility.yml
+++ b/config/mobility.yml
@@ -2,16 +2,16 @@ site_name: Mapzen Mobility
 docs_dir: src-mobility
 site_dir: dist-mobility
 
-mz:renames:
-  'images/browser-controls.png': 'turn-by-turn/images/browser-controls.png'
-  'images/browser-initial-map.png': 'turn-by-turn/images/browser-initial-map.png'
-  'images/local-browser.png': 'turn-by-turn/images/local-browser.png'
-  'images/route-map-initial.png': 'turn-by-turn/images/route-map-initial.png'
-  'images/route-map-valhalla-destination.png': 'turn-by-turn/images/route-map-valhalla-destination.png'
-  'images/route-map-valhalla-line-color.png': 'turn-by-turn/images/route-map-valhalla-line-color.png'
-  'images/route-map-valhalla.png': 'turn-by-turn/images/route-map-valhalla.png'
-  'images/start-python-server.png': 'turn-by-turn/images/start-python-server.png'
-  'images/terminal-404-error.png': 'turn-by-turn/images/terminal-404-error.png'
+# # mz:renames:
+#   'images/browser-controls.png': 'turn-by-turn/images/browser-controls.png'
+#   'images/browser-initial-map.png': 'turn-by-turn/images/browser-initial-map.png'
+#   'images/local-browser.png': 'turn-by-turn/images/local-browser.png'
+#   'images/route-map-initial.png': 'turn-by-turn/images/route-map-initial.png'
+#   'images/route-map-valhalla-destination.png': 'turn-by-turn/images/route-map-valhalla-destination.png'
+#   'images/route-map-valhalla-line-color.png': 'turn-by-turn/images/route-map-valhalla-line-color.png'
+#   'images/route-map-valhalla.png': 'turn-by-turn/images/route-map-valhalla.png'
+#   'images/start-python-server.png': 'turn-by-turn/images/start-python-server.png'
+#   'images/terminal-404-error.png': 'turn-by-turn/images/terminal-404-error.png'
 
 pages:
   - Home: index.md

--- a/config/mobility.yml
+++ b/config/mobility.yml
@@ -3,9 +3,6 @@ docs_dir: src-mobility
 site_dir: dist-mobility
 
 mz:renames:
-  'optimized_route/api-reference.md': 'optimized/api-reference.md'
-  'api-reference.md': 'turn-by-turn/api-reference.md'
-  'add-routing-to-a-map.md': 'turn-by-turn/add-routing-to-a-map.md'
   'images/browser-controls.png': 'turn-by-turn/images/browser-controls.png'
   'images/browser-initial-map.png': 'turn-by-turn/images/browser-initial-map.png'
   'images/local-browser.png': 'turn-by-turn/images/local-browser.png'
@@ -15,7 +12,6 @@ mz:renames:
   'images/route-map-valhalla.png': 'turn-by-turn/images/route-map-valhalla.png'
   'images/start-python-server.png': 'turn-by-turn/images/start-python-server.png'
   'images/terminal-404-error.png': 'turn-by-turn/images/terminal-404-error.png'
-  'turn-by-turn-overview.md': 'turn-by-turn/overview.md'
 
 pages:
   - Home: index.md

--- a/config/mobility.yml
+++ b/config/mobility.yml
@@ -35,3 +35,5 @@ extra:
   site_subtitle: 'Add routing and navigation to your web and mobile apps.'
   project_repo_url: https://github.com/valhalla/
   docs_base_url: https://github.com/valhalla/valhalla-docs/tree/master
+
+# force refresh

--- a/config/mobility.yml
+++ b/config/mobility.yml
@@ -2,6 +2,8 @@ site_name: Mapzen Mobility
 docs_dir: src-mobility
 site_dir: dist-mobility
 
+# force rebuild
+
 pages:
   - Home: index.md
   - 'Glossary': 'terminology.md'

--- a/config/mobility.yml
+++ b/config/mobility.yml
@@ -35,5 +35,3 @@ extra:
   site_subtitle: 'Add routing and navigation to your web and mobile apps.'
   project_repo_url: https://github.com/valhalla/
   docs_base_url: https://github.com/valhalla/valhalla-docs/tree/master
-
-# force refresh


### PR DESCRIPTION
Moved a bunch of mobility documentation around, which means we no longer need to add URL redirects and things at build time.

Depends on https://github.com/valhalla/valhalla-docs/issues/127 to be merged first.

Also must remove the changes to the makefile when this is in valhalla master.