### PR TITLE
delete deployment section and automated tests

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -7,8 +7,3 @@ dependencies:
     - sudo apt-get update -y
     - sudo apt-get install -y curl
     - pip install -r requirements.txt
-
-test:
-  override:
-    - cp -Lr dist $CIRCLE_ARTIFACTS/documentation
-    - echo '<a href="/documentation/">documentation</a>' > $CIRCLE_ARTIFACTS/index.html

--- a/circle.yml
+++ b/circle.yml
@@ -10,6 +10,5 @@ dependencies:
 
 test:
   override:
-    - make
     - cp -Lr dist $CIRCLE_ARTIFACTS/documentation
     - echo '<a href="/documentation/">documentation</a>' > $CIRCLE_ARTIFACTS/index.html

--- a/circle.yml
+++ b/circle.yml
@@ -11,16 +11,5 @@ dependencies:
 test:
   override:
     - make
-    - ./run-checklist.py
     - cp -Lr dist $CIRCLE_ARTIFACTS/documentation
     - echo '<a href="/documentation/">documentation</a>' > $CIRCLE_ARTIFACTS/index.html
-
-deployment:
-  staging:
-    branch: staging
-    commands:
-      - aws s3 sync dist s3://static-dev.mapzen.com/documentation/
-  release:
-    branch: master
-    commands:
-      - aws s3 sync dist $AWS_DESTINATION


### PR DESCRIPTION
builds are failing because of rearranging that has happened. this kills the deployment so we can get a snapshot on mapzen.com before the content gets edited further.